### PR TITLE
Add path-to-regexp as an explicit dependency

### DIFF
--- a/Legion.FrontEnd/package.json
+++ b/Legion.FrontEnd/package.json
@@ -70,6 +70,7 @@
     "html-webpack-plugin": "^3.2.0",
     "less": "^3.7.1",
     "less-loader": "^4.1.0",
+    "path-to-regexp": "^2.4.0",
     "style-loader": "^0.21.0",
     "uglifyjs-webpack-plugin": "^1.2.7",
     "webpack": "^4.16.1",

--- a/Legion.FrontEnd/yarn.lock
+++ b/Legion.FrontEnd/yarn.lock
@@ -4408,6 +4408,10 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
+path-to-regexp@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"


### PR DESCRIPTION
The project was broken due to an old version of path-to-regexp being installed as a dependency of react-router-dom.

#36